### PR TITLE
Use EL7

### DIFF
--- a/config/pe_build.yaml
+++ b/config/pe_build.yaml
@@ -1,4 +1,8 @@
 ---
+# See https://github.com/oscar-stack/vagrant-pe_build#global-configpe_build-settings
 pe_build:
-  version: '2017.3.2'
+  version: '2018.1.1'
   download_root: "https://s3.amazonaws.com/pe-builds/released/:version"
+
+# Use this if Minitar fails to extract the PE TAR.
+#  shared_installer: false

--- a/config/roles.yaml
+++ b/config/roles.yaml
@@ -7,11 +7,11 @@ roles:
         customize:
           - [modifyvm, !ruby/sym id, '--memory', 2048]
 
-  base_1024mb_ram:
+  base_4096mb_ram:
     providers:
       - type: virtualbox
         customize:
-          - [modifyvm, !ruby/sym id, '--memory', 1024]
+          - [modifyvm, !ruby/sym id, '--memory', 4096]
 
   master_base:
     synced_folders:
@@ -53,12 +53,16 @@ roles:
       - type: pe_agent
         master: 'puppet-master'
 
-  centos:
+  centos6:
     provisioners:
       - type: shell
         inline: 'service iptables stop; chkconfig iptables off;'
+  centos7:
+    provisioners:
+      - type: shell
+        inline: 'systemctl stop firewalld.service; chkconfig firewalld off;'
 
-  dhcp_nat:
+  dhcp_nat-el6:
     provisioners:
       - type: shell
         inline: 'iptables -F'
@@ -68,3 +72,13 @@ roles:
         inline: 'service iptables save'
       - type: shell
         inline: 'service iptables restart'
+  dhcp_nat-el7:
+    provisioners:
+      - type: shell
+        inline: 'iptables -F'
+      - type: shell
+        inline: 'iptables --table nat --append POSTROUTING --out-interface eth0 -j MASQUERADE'
+      - type: shell
+        inline: 'iptables-save'
+      - type: shell
+        inline: 'systemctl restart firewalld.service'

--- a/config/vms.yaml
+++ b/config/vms.yaml
@@ -2,25 +2,42 @@
 vms:
 
   - name: "puppet-master"
-    hostname: "puppet-master.pe-razor.stack"
-    box:  "puppetlabs/centos-6.6-64-nocm"
+    box:  "puppetlabs/centos-7.0-64-nocm"
     private_networks:
     - { ip: '192.168.50.22', virtualbox__intnet: "Razor_Network" }
     - { ip: '192.168.51.22' }
-    roles: [ "base_2048mb_ram", "master_base",  "master", "centos" ]
+    roles: [ "base_4096mb_ram", "master_base",  "master", "centos7" ]
 
   - name: "razor-server"
-    hostname: "razor-server.pe-razor.stack"
-    box:  "puppetlabs/centos-6.6-64-nocm"
+    box:  "puppetlabs/centos-7.0-64-nocm"
     private_networks:
     - { ip: '192.168.50.12', virtualbox__intnet: "Razor_Network" }
-#    - { ip: '192.168.51.12' }:
-    roles: [ "base_1024mb_ram", "agent", "centos" ]
+    - { ip: '192.168.51.12'}
+    roles: [ "base_2048mb_ram", "agent", "centos7" ]
 
   - name: "dhcp-server"
-    hostname: "dhcp-server.pe-razor.stack"
-    box:  "puppetlabs/centos-6.6-64-nocm"
+    box:  "puppetlabs/centos-7.0-64-nocm"
     private_networks:
     - { ip: '192.168.50.32', virtualbox__intnet: "Razor_Network" }
-#    - { ip: '192.168.51.32' }
-    roles: [ "agent", "dhcp_nat" ]
+    roles: [ "agent", "dhcp_nat-el7" ]
+
+## Use these values for EL6.
+#  - name: "puppet-master"
+#    box:  "puppetlabs/centos-6.6-64-nocm"
+#    private_networks:
+#    - { ip: '192.168.50.22', virtualbox__intnet: "Razor_Network" }
+#    - { ip: '192.168.51.22' }
+#    roles: [ "base_4096mb_ram", "master_base",  "master", "centos6" ]
+#
+#  - name: "razor-server"
+#    box:  "puppetlabs/centos-6.6-64-nocm"
+#    private_networks:
+#    - { ip: '192.168.50.12', virtualbox__intnet: "Razor_Network" }
+#    - { ip: '192.168.51.12'}
+#    roles: [ "base_2048mb_ram", "agent", "centos6" ]
+#
+#  - name: "dhcp-server"
+#    box:  "puppetlabs/centos-6.6-64-nocm"
+#    private_networks:
+#    - { ip: '192.168.50.32', virtualbox__intnet: "Razor_Network" }
+#    roles: [ "agent", "dhcp_nat-el6" ]


### PR DESCRIPTION
CentOS 7 will now be the default operating system. If you would like to
continue using CentOS 6, edit the vms.yaml file to use the commented-out
sections instead.

This includes bumping the amount of RAM used for the puppet master to
4GB. The Razor server will now be 2GB.

It also updates the version of PE used to 2018.1.1.