### PR TITLE
 Change hostnames to use periods instead of dashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,13 @@
     - http://docs.puppetlabs.com/pe/latest/razor_using.html
   - Expect the box to load a microkernel and just sit there wating for
     razor to instruct it.
-9. The razor client is installed on the razor-server.  You can use
+9. The razor client is installed on the razor.server.  You can use
    the client to create a policy.
 10. If you would like to connect to the puppet enterprise console you can
    connect from your machine at https://192.168.51.22.
   - The username is `admin` and the password is `puppetlabs`
+11. If you would like to connect to the Razor Server, including its API,
+   you can connect from your machine at e.g. https://192.168.51.12:8151/api.
 
 ## Creating a VM for PXE booting with Razor
 
@@ -53,11 +55,11 @@ If for some reason you don't want to use the VM definition in `example_pxe_boot_
 ## Networking Notes
 
 If you run into any DNS issues then there's a few things to know.
-The puppet-master, razor-server, and dhcp-server all have static ip
+The puppet.master, razor.server, and dhcp.server all have static ip
 addresses assigned from the vagrant configuration.  They resolve each
 other via `/etc/hosts`.  However, any new boxes you create to PXE boot
-will automatically get an ip from the dhcp-server and will resolve
-the razor-server via DNS that is setup on the dhcp-server.
+will automatically get an ip from the dhcp.server and will resolve
+the razor.server via DNS that is setup on the dhcp.server.
 
 Wondering how the PXE booted box is able to connect to the internet?
 The DHCP server is also acting like a router and forwarding ipv4
@@ -66,8 +68,8 @@ traffic to the internet from the PXE booted boxes.
 ## Stack Boot Time
 
 Total Stack Boot Time (timed on my laptop with SSD)
- 1. puppet-master 10 mins
- 2. razor-server  15 mins
- 3. dhcp-server   7  mins
+ 1. puppet.master 10 mins
+ 2. razor.server  15 mins
+ 3. dhcp.server   7  mins
 
 

--- a/config/pe_build.yaml
+++ b/config/pe_build.yaml
@@ -1,7 +1,7 @@
 ---
 # See https://github.com/oscar-stack/vagrant-pe_build#global-configpe_build-settings
 pe_build:
-  version: '2018.1.2'
+  version: '2019.1.1'
   download_root: "https://s3.amazonaws.com/pe-builds/released/:version"
 
 # Use this if Minitar fails to extract the PE TAR.

--- a/config/roles.yaml
+++ b/config/roles.yaml
@@ -31,14 +31,14 @@ roles:
       - {type: hosts}
       - type: pe_bootstrap
         version: '3.2.0'
-        master: 'puppet-master'
+        master: 'puppet.master'
 
   agent:
     provisioners:
       - {type: shell, inline: "echo 'nameserver 8.8.8.8' > /etc/resolv.conf"}
       - {type: hosts}
       - type: pe_agent
-        master: 'puppet-master'
+        master: 'puppet.master'
 
   dhcp_nat-el6:
     provisioners:

--- a/config/roles.yaml
+++ b/config/roles.yaml
@@ -53,16 +53,11 @@ roles:
   dhcp_nat-el7:
     provisioners:
       - type: shell
-        # This is needed to receive DHCP calls from the node.
-        inline: 'firewall-cmd --zone=public --add-service=dhcp --permanent'
-      - type: shell
-        # This is needed to download the bootstrap.ipxe file
-        inline: 'firewall-cmd --zone=public --add-service=tftp --permanent'
-      - type: shell
-        # This is needed to find the Razor server
-        inline: 'firewall-cmd --zone=public --add-service=dns --permanent'
+        # This default zone will open all ports, so we can get proper traffic
+        # forwarding
+        inline: 'firewall-cmd --set-default-zone=trusted'
       - type: shell
         # This is needed to send large files to the new node from Razor server
-        inline: 'firewall-cmd --zone=public --add-masquerade --permanent'
+        inline: 'firewall-cmd --zone=trusted --add-masquerade --permanent'
       - type: shell
-        inline: 'systemctl restart firewalld.service'
+        inline: 'firewall-cmd --reload'

--- a/config/roles.yaml
+++ b/config/roles.yaml
@@ -64,3 +64,23 @@ roles:
         inline: 'firewall-cmd --zone=trusted --add-masquerade --permanent'
       - type: shell
         inline: 'firewall-cmd --reload'
+
+  razor_server_symlink:
+    provisioners:
+#      These below map the hooks, tasks, and brokers directories.
+      - type: shell
+        run: always
+        inline: '[ -e /vagrant/razor-server ] && mkdir -p /opt/puppetlabs/server/apps/razor-server/share/razor-server && rm -rf /opt/puppetlabs/server/apps/razor-server/share/razor-server/hooks && ln -s -f /vagrant/razor-server/hooks /opt/puppetlabs/server/apps/razor-server/share/razor-server'
+      - type: shell
+        run: always
+        inline: '[ -e /vagrant/razor-server ] && mkdir -p /opt/puppetlabs/server/apps/razor-server/share/razor-server && rm -rf /opt/puppetlabs/server/apps/razor-server/share/razor-server/tasks && ln -s -f /vagrant/razor-server/tasks /opt/puppetlabs/server/apps/razor-server/share/razor-server'
+      - type: shell
+        run: always
+        inline: '[ -e /vagrant/razor-server ] && mkdir -p /opt/puppetlabs/server/apps/razor-server/share/razor-server && rm -rf /opt/puppetlabs/server/apps/razor-server/share/razor-server/brokers && ln -s -f /vagrant/razor-server/brokers /opt/puppetlabs/server/apps/razor-server/share/razor-server'
+      - type: shell
+        run: always
+        inline: '[ -e /vagrant/razor-server ] && mkdir -p /opt/puppetlabs/server/apps/razor-server/share/razor-server && rm -rf /opt/puppetlabs/server/apps/razor-server/share/razor-server/lib && ln -s -f /vagrant/razor-server/lib /opt/puppetlabs/server/apps/razor-server/share/razor-server'
+      - type: shell
+        run: always
+        # Restart is necessary to pick up symlinked lib directory. Service won't exist yet on the first run, so this skips if that's the case.
+        inline: '((systemctl list-units --full -all | grep -Fq "pe-razor-server.service") && service pe-razor-server restart) || true'

--- a/config/roles.yaml
+++ b/config/roles.yaml
@@ -35,6 +35,9 @@ roles:
 
   agent:
     provisioners:
+      - type: shell
+        # Run these to ensure pe_frictionless_installer.sh completes.
+        inline: 'yum update -y curl'
       - {type: shell, inline: "echo 'nameserver 8.8.8.8' > /etc/resolv.conf"}
       - {type: hosts}
       - type: pe_agent

--- a/config/vms.yaml
+++ b/config/vms.yaml
@@ -13,7 +13,7 @@ vms:
     private_networks:
     - { ip: '192.168.50.12', virtualbox__intnet: "Razor_Network" }
     - { ip: '192.168.51.12'}
-    roles: [ "medium-size", "agent", "el-stop-firewall" ]
+    roles: [ "medium-size", "agent", "el-stop-firewall", "razor_server_symlink" ]
 
   - name: "dhcp.server"
     box:  "puppetlabs/centos-7.0-64-nocm"

--- a/config/vms.yaml
+++ b/config/vms.yaml
@@ -1,42 +1,42 @@
 ---
 vms:
 
-  - name: "puppet-master"
+  - name: "puppet.master"
     box:  "puppetlabs/centos-7.0-64-nocm"
     private_networks:
     - { ip: '192.168.50.22', virtualbox__intnet: "Razor_Network" }
     - { ip: '192.168.51.22' }
     roles: [ "large-size", "master_base",  "master", "el-stop-firewall" ]
 
-  - name: "razor-server"
+  - name: "razor.server"
     box:  "puppetlabs/centos-7.0-64-nocm"
     private_networks:
     - { ip: '192.168.50.12', virtualbox__intnet: "Razor_Network" }
     - { ip: '192.168.51.12'}
     roles: [ "medium-size", "agent", "el-stop-firewall" ]
 
-  - name: "dhcp-server"
+  - name: "dhcp.server"
     box:  "puppetlabs/centos-7.0-64-nocm"
     private_networks:
     - { ip: '192.168.50.32', virtualbox__intnet: "Razor_Network" }
     roles: [ "medium-size", "agent", "dhcp_nat-el7" ]
 
 ## Use these values for EL6.
-#  - name: "puppet-master"
+#  - name: "puppet.master"
 #    box:  "puppetlabs/centos-6.6-64-nocm"
 #    private_networks:
 #    - { ip: '192.168.50.22', virtualbox__intnet: "Razor_Network" }
 #    - { ip: '192.168.51.22' }
 #    roles: [ "base_4096mb_ram", "master_base",  "master", "el-stop-firewall" ]
 #
-#  - name: "razor-server"
+#  - name: "razor.server"
 #    box:  "puppetlabs/centos-6.6-64-nocm"
 #    private_networks:
 #    - { ip: '192.168.50.12', virtualbox__intnet: "Razor_Network" }
 #    - { ip: '192.168.51.12'}
 #    roles: [ "base_2048mb_ram", "agent", "el-stop-firewall" ]
 #
-#  - name: "dhcp-server"
+#  - name: "dhcp.server"
 #    box:  "puppetlabs/centos-6.6-64-nocm"
 #    private_networks:
 #    - { ip: '192.168.50.32', virtualbox__intnet: "Razor_Network" }

--- a/puppet/manifests/site.pp
+++ b/puppet/manifests/site.pp
@@ -19,7 +19,7 @@
 
 # Define filebucket 'main':
 #filebucket { 'main':
-#  server => 'puppet-master',
+#  server => 'puppet.master',
 #  path   => false,
 #}
 
@@ -42,16 +42,16 @@ node default {
   #   class { 'my_class': }
 }
 
-node 'dhcp-server' {
+node 'dhcp.server' {
  include 'razor_dnsmasq'
  include 'razor_ipv4_forward'
 }
 
-node 'puppet-master' {
+node 'puppet.master' {
  include 'pe_env'
 }
 
-node 'razor-server' {
+node 'razor.server' {
  include 'pe_env'
  class {'pe_razor':
    enable_windows_smb => true,

--- a/puppet/modules/razor_client/manifests/init.pp
+++ b/puppet/modules/razor_client/manifests/init.pp
@@ -1,8 +1,14 @@
 class razor_client {
+  # Required for razor-client gem to install properly, since one of the
+  # dependencies (`unf`) requires native extensions.
+  package { ['gcc', 'gcc-c++']:
+    ensure => present,
+  }
 
-  package { 'pe-razor-client' :
+  package { 'razor-client' :
     ensure   => present,
     provider => puppet_gem,
+    require => [Package['gcc'], Package['gcc-c++']],
   }
 
   package { 'json_pure' :
@@ -13,7 +19,7 @@ class razor_client {
   file { '/usr/bin/razor' :
     ensure  => link,
     target  => '/opt/puppetlabs/puppet/bin/razor',
-    require => Package['pe-razor-client'],
+    require => Package['razor-client'],
   }
 
 }

--- a/puppet/modules/razor_dnsmasq/files/dnsmasq.d/hosts
+++ b/puppet/modules/razor_dnsmasq/files/dnsmasq.d/hosts
@@ -1,4 +1,4 @@
-address=/puppet-master/192.168.50.22
-address=/razor-server/192.168.50.12
-address=/dhcp-server/192.168.50.32
+address=/puppet.master/192.168.50.22
+address=/razor.server/192.168.50.12
+address=/dhcp.server/192.168.50.32
 

--- a/puppet/modules/razor_dnsmasq/manifests/init.pp
+++ b/puppet/modules/razor_dnsmasq/manifests/init.pp
@@ -60,9 +60,9 @@ class razor_dnsmasq {
   }
 
   if ($::pe_version != undef and (versioncmp( $::pe_version, '3.7.99') == -1)) {
-    $ipxe_dl_cmd = "/usr/bin/wget --no-check-certificate 'http://razor-server:8080/api/microkernel/bootstrap?nic_max=1' -O /var/lib/tftpboot/bootstrap.ipxe"
+    $ipxe_dl_cmd = "/usr/bin/wget --no-check-certificate 'http://razor.server:8080/api/microkernel/bootstrap?nic_max=1' -O /var/lib/tftpboot/bootstrap.ipxe"
   } else {
-    $ipxe_dl_cmd = "/usr/bin/wget --no-check-certificate 'https://razor-server:8151/api/microkernel/bootstrap?nic_max=1&http_port=8150' -O /var/lib/tftpboot/bootstrap.ipxe"
+    $ipxe_dl_cmd = "/usr/bin/wget --no-check-certificate 'https://razor.server:8151/api/microkernel/bootstrap?nic_max=1&http_port=8150' -O /var/lib/tftpboot/bootstrap.ipxe"
   }
 
   exec { 'get bootstrap.ipxe from razor server' :


### PR DESCRIPTION
This is primarily a workaround for some WIFI networks and Ubuntu
installers where the wrong domain will be added to hostnames
that do not contain a period.

Hostnames will be `puppet.master`, `razor.server`, and
`dhcp.server`.

Also included: 
- PE update to 2019.1.1
- Migration to FOSS razor-client
- Firewall strategy change
- Development symlink to use local tasks, hooks, brokers, and lib.